### PR TITLE
[Design/#53]  home 팩 image 있는 버전으로 변경

### DIFF
--- a/src/shared/ui/item/PackImageCard.tsx
+++ b/src/shared/ui/item/PackImageCard.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { IcSvgMore, IcSvgWish, IcSvgWishBtn } from "@/shared/icons";
+import { Tag2Btn } from "@/shared/ui/Tag2Btn";
+import { useRouter } from "next/navigation";
+import { PackImageFolderBg } from "./pack-image-card-bg";
+
+export interface PackImageCardData {
+  id: string;
+  tag: string;
+  tagColor?: string;
+  itemCount: number;
+  title: string;
+  author: string;
+  liked?: boolean;
+  imageSrc?: string;
+  imageAlt?: string;
+  href?: string;
+}
+
+interface PackImageCardProps extends Omit<PackImageCardData, "id"> {
+  onLike?: () => void;
+  onMore?: () => void;
+}
+
+export function PackImageCard({
+  tag,
+  itemCount = 8,
+  title,
+  author,
+  liked = false,
+  imageSrc,
+  imageAlt = "",
+  onLike,
+  onMore,
+  href,
+}: PackImageCardProps) {
+  const [isLiked, setIsLiked] = useState(liked);
+  const router = useRouter();
+
+  const handleLike = () => {
+    setIsLiked((prev) => !prev);
+    onLike?.();
+  };
+
+  const handleClick = () => {
+    if (href) {
+      router.push(href);
+    }
+  };
+
+  return (
+    <div
+      className="relative w-full min-h-[322px] cursor-pointer"
+      onClick={handleClick}
+      role={href ? "link" : undefined}
+    >
+      <PackImageFolderBg className="absolute inset-0 h-full w-full" />
+
+      <div className="relative z-10 flex h-full flex-col px-5 pb-5 pt-4 sm:px-7 sm:pb-6 sm:pt-4">
+        <div className="flex items-center gap-2">
+          <Tag2Btn status>{tag}</Tag2Btn>
+          <span className="shrink-0 text-xs text-neutral-400 sm:text-sm">
+            {itemCount} items
+          </span>
+        </div>
+
+        <div className="mt-4 flex items-start justify-between gap-2 sm:mt-5">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5 sm:gap-2">
+              <h3 className="truncate text-base font-bold text-neutral-900 sm:text-lg">
+                {title}
+              </h3>
+
+              <button
+                type="button"
+                aria-label="좋아요"
+                className="shrink-0 text-neutral-300 transition-colors hover:text-rose-400"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleLike();
+                }}
+              >
+                {isLiked ? (
+                  <IcSvgWish className="h-5 w-5 sm:h-6 sm:w-6 text-red-500" />
+                ) : (
+                  <IcSvgWishBtn className="h-5 w-5 sm:h-6 sm:w-6" />
+                )}
+              </button>
+            </div>
+
+            <p className="mt-0.5 truncate text-xs text-neutral-400 sm:mt-1 sm:text-sm">
+              {author}
+            </p>
+          </div>
+
+          <button
+            type="button"
+            aria-label="더보기"
+            className="shrink-0 rounded-full p-0.5 text-neutral-400 transition-colors hover:bg-neutral-100"
+            onClick={(e) => {
+              e.stopPropagation();
+              onMore?.();
+            }}
+          >
+            <IcSvgMore className="h-5 w-5 sm:h-6 sm:w-6" />
+          </button>
+        </div>
+
+        {/* Image area */}
+        <div className="relative mt-4 aspect-[307/138] w-full overflow-hidden rounded-xl bg-neutral-100 sm:mt-5">
+          {imageSrc ? (
+            <Image
+              src={imageSrc}
+              alt={imageAlt}
+              fill
+              sizes="(max-width: 640px) 100vw, 600px"
+              className="object-cover"
+              priority={false}
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <span className="text-neutral-300 text-sm">No Image</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/item/pack-image-card-bg.tsx
+++ b/src/shared/ui/item/pack-image-card-bg.tsx
@@ -1,0 +1,110 @@
+export function PackImageFolderBg({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="100%"
+      viewBox="0 0 351 322"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      preserveAspectRatio="none"
+      style={{ height: 322 }}
+    >
+      <g filter="url(#filter0_ddd_packimg)">
+        {/* Back tab - beige */}
+        <path
+          d="M8 26C8 14.9543 16.9543 6 28 6H323C334.046 6 343 14.9543 343 26V292C343 303.046 334.046 312 323 312H28C16.9543 312 8 303.046 8 292V26Z"
+          fill="#EDEAE4"
+          shapeRendering="crispEdges"
+        />
+        {/* Front body - white */}
+        <path
+          d="M8 26.0005C8 14.9548 16.9543 6.00052 28 6.00049L224.123 6.00002C228.781 6.00001 233.294 7.62621 236.881 10.598L265.557 34.3517C269.144 37.3234 273.656 38.9496 278.315 38.9497L323 38.95C334.046 38.9501 343 47.9044 343 58.95V292C343 303.046 334.046 312 323 312H28C16.9543 312 8 303.046 8 292V26.0005Z"
+          fill="white"
+        />
+        {/* Folder icon */}
+        <path
+          d="M275.59 28.25C275.169 28.25 274.813 28.1042 274.521 27.8125C274.229 27.5208 274.083 27.1645 274.083 26.7435V17.2565C274.083 16.8355 274.229 16.4792 274.521 16.1875C274.813 15.8958 275.169 15.75 275.59 15.75H279.542C279.743 15.75 279.936 15.789 280.121 15.8671C280.306 15.945 280.468 16.0524 280.604 16.1892L281.832 17.4167H288.41C288.831 17.4167 289.188 17.5625 289.479 17.8542C289.771 18.1458 289.917 18.5022 289.917 18.9231V26.7435C289.917 27.1645 289.771 27.5208 289.479 27.8125C289.188 28.1042 288.831 28.25 288.41 28.25H275.59Z"
+          fill="#9D9A95"
+        />
+        {/* PACK text */}
+        <path
+          d="M296.851 27V17.8086H300.304C302.411 17.8086 303.541 19.0908 303.541 20.8555C303.541 22.6201 302.398 23.8896 300.278 23.8896H298.501V27H296.851ZM298.501 22.5312H300.05C301.294 22.5312 301.853 21.833 301.853 20.8555C301.853 19.8652 301.294 19.1924 300.05 19.1924H298.501V22.5312ZM305.264 27H303.499L306.736 17.8086H308.768L312.018 27H310.253L309.491 24.7275H306.025L305.264 27ZM306.47 23.3945H309.047L307.79 19.6875H307.714L306.47 23.3945ZM319.123 20.9062C318.933 19.8018 318.044 19.167 316.927 19.167C315.416 19.167 314.362 20.3223 314.362 22.4043C314.362 24.5117 315.429 25.6416 316.927 25.6416C318.019 25.6416 318.907 25.0322 319.123 23.9531H320.786C320.532 25.7178 319.085 27.127 316.901 27.127C314.477 27.127 312.699 25.3623 312.699 22.4043C312.699 19.4336 314.502 17.6816 316.901 17.6816C318.933 17.6816 320.507 18.8623 320.786 20.9062H319.123ZM322.458 27V17.8086H324.108V22.0361H324.235L327.828 17.8086H329.847L326.292 21.9346L329.885 27H327.892L325.137 23.0518L324.108 24.2578V27H322.458Z"
+          fill="#9D9A95"
+        />
+      </g>
+      <defs>
+        <filter
+          id="filter0_ddd_packimg"
+          x="0"
+          y="0"
+          width="351"
+          height="322"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="0.5" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="BackgroundImageFix"
+            result="effect1_dropShadow"
+          />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dy="1" />
+          <feGaussianBlur stdDeviation="2" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="effect1_dropShadow"
+            result="effect2_dropShadow"
+          />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dy="2" />
+          <feGaussianBlur stdDeviation="4" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.06 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="effect2_dropShadow"
+            result="effect3_dropShadow"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect3_dropShadow"
+            result="shape"
+          />
+        </filter>
+      </defs>
+    </svg>
+  );
+}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -4,14 +4,21 @@ import React from "react";
 import { motion } from "framer-motion";
 import { useRouter } from "next/navigation";
 
-import { SearchBarOverlay, useSearchBarTransition } from "@/features/search/transition";
+import {
+  SearchBarOverlay,
+  useSearchBarTransition,
+} from "@/features/search/transition";
 import { HomeSearchHeader } from "@/widgets/home-search-header/ui/HomeSearchHeader";
 import Tag1Btn from "@/shared/ui/Tag1Btn";
 import IcSvgArrowRightSmall from "@/shared/icons/ic_arrowrightsmall";
 import { PACKS_BY_TAG, Tag, TAGS } from "@/features/search/model/mock";
-import { MAIN_GREETINGS, pickRandomGreeting, type Greeting } from "../model/greeting";
+import {
+  MAIN_GREETINGS,
+  pickRandomGreeting,
+  type Greeting,
+} from "../model/greeting";
 
-import {  type PackCardData } from "@/shared/ui/item/PackCard";
+import { type PackImageCardData } from "@/shared/ui/item/PackImageCard";
 
 import {
   MOCK_HOME_PACKS_API,
@@ -38,22 +45,74 @@ export function HomePage() {
   const onFilterClick = () => router.push("/filter-search");
 
   const [selectedTag, setSelectedTag] = React.useState<Tag>(TAGS[0]);
-  const newPacks = PACKS_BY_TAG[selectedTag] ?? [];
+  const [trendingByTag, setTrendingByTag] = React.useState<
+    Record<string, HomePackApiDto[]>
+  >({});
+  const [, setFetchError] = React.useState<string | null>(null);
 
-  const [greeting, setGreeting] = React.useState<Greeting>(() => MAIN_GREETINGS[0]);
+  const newPacks =
+    trendingByTag[selectedTag] ?? PACKS_BY_TAG[selectedTag] ?? [];
+
+  const [greeting, setGreeting] = React.useState<Greeting>(
+    () => MAIN_GREETINGS[0],
+  );
   React.useEffect(() => {
     setGreeting(pickRandomGreeting());
   }, []);
 
-  //  API 응답(목데이터) -> 카테고리별 묶기
-  const categoryMap = React.useMemo(() => groupByCategory(MOCK_HOME_PACKS_API), []);
+  // fetch trending packs by tag
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await fetch("/api/v1/packs/trending-tags");
+        if (!res.ok) {
+          if (res.status === 404) {
+            setFetchError("데이터를 찾을 수 없습니다. (404)");
+          } else {
+            setFetchError(`서버 오류: ${res.status}`);
+          }
+          return;
+        }
+        const data = await res.json();
 
-  // 온보딩 선택 카테고리 순서대로 섹션 구성 + PackCardData로 매핑
+        const map: Record<string, HomePackApiDto[]> = {};
+        TAGS.forEach((t) => {
+          const list = data[t] ?? [];
+          map[t] = Array.isArray(list) ? list.slice(0, 3) : [];
+        });
+
+        if (mounted) {
+          setTrendingByTag(map);
+          setFetchError(null);
+        }
+      } catch (err: unknown) {
+        if (mounted) {
+          const msg =
+            err instanceof Error
+              ? err.message
+              : "네트워크 오류가 발생했습니다.";
+          setFetchError(msg);
+        }
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  //  API 응답(목데이터) -> 카테고리별 묶기
+  const categoryMap = React.useMemo(
+    () => groupByCategory(MOCK_HOME_PACKS_API),
+    [],
+  );
+
+  // 온보딩 선택 카테고리 순서대로 섹션 구성 + PackImageCardData로 매핑
   const sections = React.useMemo(() => {
     return MOCK_ONBOARDING_CATEGORIES.map((category: string) => {
       const list: HomePackApiDto[] = categoryMap.get(category) ?? [];
 
-      const packs: PackCardData[] = list.map((p) => ({
+      const packs: PackImageCardData[] = list.map((p) => ({
         id: String(p.id),
         tag: p.contextCategory,
         itemCount: p.items,
@@ -67,7 +126,7 @@ export function HomePage() {
         title: getCategoryTitle(category),
         packs,
       };
-    }).filter((s: { packs: PackCardData[] }) => s.packs.length > 0);
+    }).filter((s: { packs: PackImageCardData[] }) => s.packs.length > 0);
   }, [categoryMap]);
 
   return (
@@ -92,21 +151,32 @@ export function HomePage() {
       </motion.div>
 
       <div ref={searchBarRef} className="mt-6">
-        <HomeSearchHeader onSearchBarClick={startTransition} onFilterClick={onFilterClick} />
+        <HomeSearchHeader
+          onSearchBarClick={startTransition}
+          onFilterClick={onFilterClick}
+        />
       </div>
 
-      <SearchBarOverlay forward={forwardOverlay} return={returnOverlay} config={transitionConfig} />
+      <SearchBarOverlay
+        forward={forwardOverlay}
+        return={returnOverlay}
+        config={transitionConfig}
+      />
 
-      <section className="mt-8 space-y-10">
+      <section className="mt-8 space-y-6">
         {sections.map((s) => (
           <div key={s.category}>
-            <h2 className="text-[18px] font-bold text-neutral-900">{s.title}</h2>
+            <h2 className="text-[18px] font-bold text-neutral-900">
+              {s.title}
+            </h2>
             <PackCarousel packs={s.packs} />
           </div>
         ))}
 
         <div>
-          <h2 className="text-[18px] font-bold text-neutral-900">지금 등록된 따끈따끈한 신상 팩</h2>
+          <h2 className="text-[18px] font-bold text-neutral-900">
+            지금 등록된 따끈따끈한 신상 팩
+          </h2>
 
           <div className="mt-6 -mx-5 px-5 overflow-x-auto">
             <div className="flex gap-2 w-max pb-2">
@@ -132,8 +202,12 @@ export function HomePage() {
               >
                 <div className="h-12 w-12 rounded-xl bg-neutral-900 shrink-0" />
                 <div className="min-w-0 flex-1">
-                  <p className="type-headline2 text-neutral-900 truncate">{item.title}</p>
-                  <p className="text-label-subtle type-caption1 truncate">{item.nickname}</p>
+                  <p className="type-headline2 text-neutral-900 truncate">
+                    {item.title}
+                  </p>
+                  <p className="text-label-subtle type-caption1 truncate">
+                    {item.nickname}
+                  </p>
                 </div>
                 <IcSvgArrowRightSmall className="w-8 h-8 text-label-subtle shrink-0" />
               </button>

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -45,10 +45,7 @@ export function HomePage() {
   const onFilterClick = () => router.push("/filter-search");
 
   const [selectedTag, setSelectedTag] = React.useState<Tag>(TAGS[0]);
-  const [trendingByTag, setTrendingByTag] = React.useState<
-    Record<string, HomePackApiDto[]>
-  >({});
-  const [, setFetchError] = React.useState<string | null>(null);
+  const [trendingByTag] = React.useState<Record<string, HomePackApiDto[]>>({});
 
   const newPacks =
     trendingByTag[selectedTag] ?? PACKS_BY_TAG[selectedTag] ?? [];
@@ -60,54 +57,11 @@ export function HomePage() {
     setGreeting(pickRandomGreeting());
   }, []);
 
-  // fetch trending packs by tag
-  React.useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        const res = await fetch("/api/v1/packs/trending-tags");
-        if (!res.ok) {
-          if (res.status === 404) {
-            setFetchError("데이터를 찾을 수 없습니다. (404)");
-          } else {
-            setFetchError(`서버 오류: ${res.status}`);
-          }
-          return;
-        }
-        const data = await res.json();
-
-        const map: Record<string, HomePackApiDto[]> = {};
-        TAGS.forEach((t) => {
-          const list = data[t] ?? [];
-          map[t] = Array.isArray(list) ? list.slice(0, 3) : [];
-        });
-
-        if (mounted) {
-          setTrendingByTag(map);
-          setFetchError(null);
-        }
-      } catch (err: unknown) {
-        if (mounted) {
-          const msg =
-            err instanceof Error
-              ? err.message
-              : "네트워크 오류가 발생했습니다.";
-          setFetchError(msg);
-        }
-      }
-    })();
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  //  API 응답(목데이터) -> 카테고리별 묶기
   const categoryMap = React.useMemo(
     () => groupByCategory(MOCK_HOME_PACKS_API),
     [],
   );
 
-  // 온보딩 선택 카테고리 순서대로 섹션 구성 + PackImageCardData로 매핑
   const sections = React.useMemo(() => {
     return MOCK_ONBOARDING_CATEGORIES.map((category: string) => {
       const list: HomePackApiDto[] = categoryMap.get(category) ?? [];
@@ -130,7 +84,7 @@ export function HomePage() {
   }, [categoryMap]);
 
   return (
-    <div className="min-h-dvh bg-background-alternative2 pt-12 px-5 pb-35">
+    <div className="min-h-dvh bg-background-alternative pt-12 px-5 pb-35">
       <motion.div
         initial={false}
         animate={{ opacity: titleVisible ? 1 : 0, y: titleVisible ? 0 : -8 }}

--- a/src/views/home/ui/PackCarousel.tsx
+++ b/src/views/home/ui/PackCarousel.tsx
@@ -1,59 +1,71 @@
 import React from "react";
-import { PackCard, type PackCardData } from "@/shared/ui/item/PackCard";
+import {
+  PackImageCard,
+  type PackImageCardData,
+} from "@/shared/ui/item/PackImageCard";
 
-export function PackCarousel({ packs }: { packs: PackCardData[] }) {
-    const scrollerRef = React.useRef<HTMLDivElement>(null);
-    const [active, setActive] = React.useState(0);
-  
-    const onScroll = React.useCallback(() => {
-      const el = scrollerRef.current;
-      if (!el) return;
-      const slideWidth = el.clientWidth;
-      const nextIndex = Math.round(el.scrollLeft / slideWidth);
-      setActive(Math.max(0, Math.min(packs.length - 1, nextIndex)));
-    }, [packs.length]);
-  
-    const scrollToIndex = (idx: number) => {
-      const el = scrollerRef.current;
-      if (!el) return;
-      const slideWidth = el.clientWidth;
-      el.scrollTo({ left: idx * slideWidth, behavior: "smooth" });
-    };
-  
-    return (
-      <div className="mt-4">
-        <div
-          ref={scrollerRef}
-          onScroll={onScroll}
-          className="-mx-5 px-5 overflow-x-auto snap-x snap-mandatory"
-        >
-          <div className="flex w-max gap-4 pb-3">
-            {packs.map((p) => (
-              <div
-                key={p.id}
-                className="w-[calc(100vw-40px)] max-w-[420px] snap-center"
-              >
-                <PackCard {...p} />
-              </div>
-            ))}
-          </div>
-        </div>
-  
-        <div className="mt-2 flex items-center justify-center gap-2">
-          {packs.map((_, i) => (
-            <button
-              key={i}
-              type="button"
-              aria-label={`slide ${i + 1}`}
-              onClick={() => scrollToIndex(i)}
-              className={[
-                "h-1.5 w-1.5 rounded-full transition-opacity",
-                i === active ? "bg-neutral-900 opacity-100" : "bg-neutral-300 opacity-70",
-              ].join(" ")}
-            />
+const fallbackImageSrc = "/splash-bg.png";
+const fallbackImageAlt = "Mock pack image";
+
+export function PackCarousel({ packs }: { packs: PackImageCardData[] }) {
+  const scrollerRef = React.useRef<HTMLDivElement>(null);
+  const [active, setActive] = React.useState(0);
+
+  const onScroll = React.useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const slideWidth = el.clientWidth;
+    const nextIndex = Math.round(el.scrollLeft / slideWidth);
+    setActive(Math.max(0, Math.min(packs.length - 1, nextIndex)));
+  }, [packs.length]);
+
+  const scrollToIndex = (idx: number) => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const slideWidth = el.clientWidth;
+    el.scrollTo({ left: idx * slideWidth, behavior: "smooth" });
+  };
+
+  return (
+    <div className="mt-4">
+      <div
+        ref={scrollerRef}
+        onScroll={onScroll}
+        className="-mx-5 px-5 overflow-x-auto overflow-y-hidden snap-x snap-mandatory"
+      >
+        <div className="flex w-max gap-4 pb-2">
+          {packs.map((p) => (
+            <div
+              key={p.id}
+              className="w-[calc(100vw-40px)] max-w-[420px] min-h-[320px] snap-center"
+            >
+              <PackImageCard
+                {...p}
+                href={`/pack/${p.id}`}
+                imageSrc={p.imageSrc?.trim() ? p.imageSrc : fallbackImageSrc}
+                imageAlt={p.imageAlt ?? fallbackImageAlt}
+              />
+            </div>
           ))}
         </div>
       </div>
-    );
-  }
-  
+
+      <div className="mt-2 flex items-center justify-center gap-2">
+        {packs.map((_, i) => (
+          <button
+            key={i}
+            type="button"
+            aria-label={`slide ${i + 1}`}
+            onClick={() => scrollToIndex(i)}
+            className={[
+              "h-1.5 w-1.5 rounded-full transition-opacity",
+              i === active
+                ? "bg-neutral-900 opacity-100"
+                : "bg-neutral-300 opacity-70",
+            ].join(" ")}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 Summary

> #️⃣ 연관된 이슈

<!-- close #123 -->

close #53

---

## 📋 작업 상세 내용

<!-- "•" 으로 상세 표기 -->
- 디자인과 동일하게 UI 변경 (목데이터)
---

### 📌 앞으로의 작업 (선택)
- 지금뜨는 팩 태그 api 연결 
- 팩 생성 api 연결
- ㅣ로그인 퍼블시링 
- (근데 피그마와 별도로 이미지 높이를 더 키워야할 것 같은...? 아래 여백이 어색한느낌 듭니다)
<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->

### 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->
<img width="1027" height="957" alt="image" src="https://github.com/user-attachments/assets/00c8aee3-85aa-4306-b533-3a6631bf80e7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New pack card design with image display, title, author, tag, like button and "more" actions.
  * Clickable cards that navigate when a link is provided.
  * Image fallbacks and accessible labels for actions.
  * New folder-styled visual background element.
  * Carousels and home lists now render the new image-based cards and preserve scrolling behavior.
* **Enhancements**
  * Trending packs integrated into home selection and layout tweaks for tighter spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->