### PR TITLE
[Feature/#57] home, search API 연결, 유저스토어 전역 사용

### DIFF
--- a/src/features/search/model/types.ts
+++ b/src/features/search/model/types.ts
@@ -1,0 +1,23 @@
+import type { PackCardData } from "@/shared/ui/item/PackCard";
+
+export type PackSearchDto = {
+  id: string;
+  tag: string;
+  itemCount: number;
+  title: string;
+  author: string; 
+  liked?: boolean;
+  description?: string;
+  date?: string;
+};
+
+export const toPackCardData = (dto: PackSearchDto): PackCardData => ({
+  id: dto.id,
+  tag: dto.tag,
+  itemCount: dto.itemCount,
+  title: dto.title,
+  author: dto.author,
+  liked: dto.liked ?? false,
+  description: dto.description,
+  date: dto.date,
+});

--- a/src/features/search/model/useSearchPacks.ts
+++ b/src/features/search/model/useSearchPacks.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/shared/api/apiClient";
+import type { PackSearchDto } from "./types";
+
+type SearchPacksResponse = {
+  items: PackSearchDto[];
+  page: number;
+  size: number;
+  total: number;
+  hasNext: boolean;
+};
+
+export const useSearchPacks = (keyword: string) => {
+  const trimmedKeyword = keyword.trim();
+
+  return useQuery({
+    queryKey: ["packs", "search", trimmedKeyword],
+    enabled: trimmedKeyword.length > 0,
+
+    queryFn: async () => {
+      const { data } = await apiClient.get<SearchPacksResponse>(
+        "/api/v1/packs/search",
+        {
+          params: { q: trimmedKeyword },
+        }
+      );
+      return data.items;
+    },
+  });
+};

--- a/src/features/search/ui/SearchInput.tsx
+++ b/src/features/search/ui/SearchInput.tsx
@@ -7,29 +7,26 @@ type Props = {
   isSearchMode?: boolean;
   query: string;
   onChange: (v: string) => void;
-  onEnterSearchMode?: () => void; // 검색 페이지 이동
+  onEnter?: () => void; // Enter 처리만
+  onSearch?: (q: string) => void;
 };
 
 const barClass =
   "flex h-10 items-center gap-2 rounded-xl bg-common-0 px-3 transition-all duration-300";
-const placeholderClass =
-  "text-sm text-neutral-400";
+const placeholderClass = "text-sm text-neutral-400";
 
 export function SearchInput({
   isSearchMode = false,
   query,
   onChange,
-  onEnterSearchMode,
+  onEnter,
+  onSearch,
 }: Props) {
-  const handleEnterSearch = () => {
-    if (!isSearchMode) onEnterSearchMode?.();
-  };
-
   if (!isSearchMode) {
     return (
       <button
         type="button"
-        onClick={handleEnterSearch}
+        onClick={() => onSearch?.(query)}
         className={`${barClass} w-full cursor-pointer text-left`}
         aria-label="검색 페이지로 이동"
       >
@@ -45,7 +42,12 @@ export function SearchInput({
       <input
         value={query}
         onChange={(e) => onChange(e.target.value)}
-        onKeyDown={(e) => e.key === "Enter" && onEnterSearchMode?.()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            onEnter?.();
+            onSearch?.(query);
+          }
+        }}
         placeholder="다양한 팩을 검색해보세요."
         className="h-full w-full bg-transparent text-sm text-neutral-800 outline-none placeholder:text-neutral-400"
       />

--- a/src/shared/lib/useDebounce.ts
+++ b/src/shared/lib/useDebounce.ts
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+export function useDebounce<T>(value: T, delay = 350) {
+  const [debounced, setDebounced] = React.useState(value);
+
+  React.useEffect(() => {
+    const id = window.setTimeout(() => setDebounced(value), delay);
+    return () => window.clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/src/views/home/model/useTrendingTags.ts
+++ b/src/views/home/model/useTrendingTags.ts
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/shared/api/apiClient";
+import type { HomePackApiDto } from "./mockHome";
+
+export type TrendingTagsResponse = Record<string, HomePackApiDto[]>;
+
+const CATEGORY_ORDER = [
+  "공부/시험",
+  "면접/취준",
+  "업무/출근",
+  "약속/데이트",
+  "운동/산책",
+  "여행/캠핑",
+  "취미/작업",
+  "육아/반려동물",
+] as const;
+
+type CategoryKey = (typeof CATEGORY_ORDER)[number];
+
+export const useTrendingTags = () => {
+  return useQuery({
+    queryKey: ["home", "trending-tags"],
+    queryFn: async () => {
+      const { data } =
+        await apiClient.get<TrendingTagsResponse>(
+          "/api/v1/packs/trending-tags",
+        );
+      return data;
+    },
+
+    select: (data) => {
+      const keys = Object.keys(data);
+
+      const ordered = [
+        ...CATEGORY_ORDER.filter((k) => keys.includes(k)),
+        ...keys.filter(
+          (k): k is string =>
+            !CATEGORY_ORDER.includes(k as CategoryKey)
+        ),
+      ];
+
+      const visibleTags = ordered.filter(
+        (k) => (data[k]?.length ?? 0) > 0
+      );
+
+      return {
+        raw: data,
+        tags: visibleTags,
+      };
+    },
+  });
+};

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -11,26 +11,19 @@ import {
 import { HomeSearchHeader } from "@/widgets/home-search-header/ui/HomeSearchHeader";
 import Tag1Btn from "@/shared/ui/Tag1Btn";
 import IcSvgArrowRightSmall from "@/shared/icons/ic_arrowrightsmall";
-import { PACKS_BY_TAG, Tag, TAGS } from "@/features/search/model/mock";
+
 import {
   MAIN_GREETINGS,
   pickRandomGreeting,
   type Greeting,
 } from "../model/greeting";
 
-import { type PackImageCardData } from "@/shared/ui/item/PackImageCard";
-
-import {
-  MOCK_HOME_PACKS_API,
-  MOCK_ONBOARDING_CATEGORIES,
-  getCategoryTitle,
-  groupByCategory,
-  type HomePackApiDto,
-} from "../model/mockHome";
-import { PackCarousel } from "./PackCarousel";
+import { useTrendingTags } from "../model/useTrendingTags";
+import type { HomePackApiDto } from "../model/mockHome";
 
 export function HomePage() {
   const router = useRouter();
+
   const {
     searchBarRef,
     titleVisible,
@@ -41,47 +34,39 @@ export function HomePage() {
     transitionConfig,
   } = useSearchBarTransition(router);
 
+  // TODO: 실제 로그인 유저 닉네임으로 교체
   const nickname = "홍길동";
   const onFilterClick = () => router.push("/filter-search");
 
-  const [selectedTag, setSelectedTag] = React.useState<Tag>(TAGS[0]);
-  const [trendingByTag] = React.useState<Record<string, HomePackApiDto[]>>({});
-
-  const newPacks =
-    trendingByTag[selectedTag] ?? PACKS_BY_TAG[selectedTag] ?? [];
-
   const [greeting, setGreeting] = React.useState<Greeting>(
-    () => MAIN_GREETINGS[0],
+    () => MAIN_GREETINGS[0]
   );
+
   React.useEffect(() => {
     setGreeting(pickRandomGreeting());
   }, []);
 
-  const categoryMap = React.useMemo(
-    () => groupByCategory(MOCK_HOME_PACKS_API),
-    [],
+  const { data, isLoading, isError } = useTrendingTags();
+
+  const tags = React.useMemo(
+    () => data?.tags ?? [],
+    [data]
+  );
+  
+  const rawByCategory = React.useMemo(
+    () => data?.raw ?? {},
+    [data]
   );
 
-  const sections = React.useMemo(() => {
-    return MOCK_ONBOARDING_CATEGORIES.map((category: string) => {
-      const list: HomePackApiDto[] = categoryMap.get(category) ?? [];
+  const [selectedTag, setSelectedTag] = React.useState<string>("");
 
-      const packs: PackImageCardData[] = list.map((p) => ({
-        id: String(p.id),
-        tag: p.contextCategory,
-        itemCount: p.items,
-        title: p.title,
-        author: p.nickname,
-        liked: false,
-      }));
+  React.useEffect(() => {
+    if (!selectedTag && tags.length > 0) {
+      setSelectedTag(tags[0]);
+    }
+  }, [tags, selectedTag]);
 
-      return {
-        category,
-        title: getCategoryTitle(category),
-        packs,
-      };
-    }).filter((s: { packs: PackImageCardData[] }) => s.packs.length > 0);
-  }, [categoryMap]);
+  const newPacks: HomePackApiDto[] = rawByCategory[selectedTag] ?? [];
 
   return (
     <div className="min-h-dvh bg-background-alternative pt-12 px-5 pb-35">
@@ -99,6 +84,8 @@ export function HomePage() {
             {greeting.line2}
           </h1>
         </div>
+
+        {/* TODO: 프로필 이미지 */}
         <div className="shrink-0">
           <div className="h-14 w-14 rounded-full bg-neutral-900" />
         </div>
@@ -117,24 +104,23 @@ export function HomePage() {
         config={transitionConfig}
       />
 
-      <section className="mt-8 space-y-6">
-        {sections.map((s) => (
-          <div key={s.category}>
-            <h2 className="text-[18px] font-bold text-neutral-900">
-              {s.title}
-            </h2>
-            <PackCarousel packs={s.packs} />
-          </div>
-        ))}
+      {/* 하단 신상 팩 영역 */}
+      <section className="mt-8">
+        <h2 className="text-[18px] font-bold text-neutral-900">
+          지금 등록된 따끈따끈한 신상 팩
+        </h2>
 
-        <div>
-          <h2 className="text-[18px] font-bold text-neutral-900">
-            지금 등록된 따끈따끈한 신상 팩
-          </h2>
+        <div className="mt-6 -mx-5 px-5 overflow-x-auto">
+          <div className="flex gap-2 w-max pb-2">
+            {isLoading && (
+              <div className="text-sm text-neutral-500 px-1">
+                태그 불러오는 중...
+              </div>
+            )}
 
-          <div className="mt-6 -mx-5 px-5 overflow-x-auto">
-            <div className="flex gap-2 w-max pb-2">
-              {TAGS.map((t) => (
+            {!isLoading &&
+              !isError &&
+              tags.map((t) => (
                 <Tag1Btn
                   key={t}
                   mode="btn"
@@ -144,15 +130,35 @@ export function HomePage() {
                   {t}
                 </Tag1Btn>
               ))}
-            </div>
-          </div>
 
-          <div className="mt-4 rounded-xl border border-common-0 bg-common-0 overflow-hidden">
-            {newPacks.map((item) => (
+            {isError && (
+              <div className="text-sm text-red-500 px-1">
+                태그를 불러오지 못했습니다.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-xl border border-common-0 bg-common-0 overflow-hidden">
+          {isLoading ? (
+            <div className="px-4 py-6 text-sm text-neutral-500">
+              데이터를 불러오는 중...
+            </div>
+          ) : isError ? (
+            <div className="px-4 py-6 text-sm text-red-500">
+              데이터를 불러오지 못했습니다.
+            </div>
+          ) : newPacks.length === 0 ? (
+            <div className="px-4 py-6 text-sm text-neutral-500">
+              아직 등록된 팩이 없어요.
+            </div>
+          ) : (
+            newPacks.map((item) => (
               <button
                 key={item.id}
                 type="button"
                 className="w-full text-left px-4 py-4 flex items-center gap-4 border-b border-neutral-200 last:border-b-0"
+                onClick={() => router.push(`/packs/${item.id}`)}
               >
                 <div className="h-12 w-12 rounded-xl bg-neutral-900 shrink-0" />
                 <div className="min-w-0 flex-1">
@@ -165,8 +171,8 @@ export function HomePage() {
                 </div>
                 <IcSvgArrowRightSmall className="w-8 h-8 text-label-subtle shrink-0" />
               </button>
-            ))}
-          </div>
+            ))
+          )}
         </div>
       </section>
     </div>

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -17,13 +17,16 @@ import {
   pickRandomGreeting,
   type Greeting,
 } from "../model/greeting";
+import { useUserStore } from "@/entities/user/model/useUserStore";
+import { isProfileDefaultColor } from "@/entities/user/model";
+import { PROFILE_COLOR_CLASS } from "@/views/my-page/ui/MyPage";
 
 import { useTrendingTags } from "../model/useTrendingTags";
 import type { HomePackApiDto } from "../model/mockHome";
 
 export function HomePage() {
   const router = useRouter();
-
+  const user = useUserStore((state) => state.user);
   const {
     searchBarRef,
     titleVisible,
@@ -34,8 +37,9 @@ export function HomePage() {
     transitionConfig,
   } = useSearchBarTransition(router);
 
-  // TODO: 실제 로그인 유저 닉네임으로 교체
-  const nickname = "홍길동";
+  const nickname = user?.name ?? "사용자";
+  const profileImageUrl = user?.profileImageUrl;
+  const profileInitial = nickname.charAt(0).toUpperCase();
   const onFilterClick = () => router.push("/filter-search");
 
   const [greeting, setGreeting] = React.useState<Greeting>(
@@ -85,9 +89,25 @@ export function HomePage() {
           </h1>
         </div>
 
-        {/* TODO: 프로필 이미지 */}
         <div className="shrink-0">
-          <div className="h-14 w-14 rounded-full bg-neutral-900" />
+          {profileImageUrl && !isProfileDefaultColor(profileImageUrl) ? (
+            <div
+              className="h-14 w-14 rounded-full bg-neutral-300 bg-cover bg-center"
+              style={{ backgroundImage: `url(${profileImageUrl})` }}
+              aria-label={`${nickname} 프로필 이미지`}
+              role="img"
+            />
+          ) : (
+            <div
+              className={`h-14 w-14 rounded-full flex items-center justify-center text-white font-bold ${
+                profileImageUrl && isProfileDefaultColor(profileImageUrl)
+                  ? PROFILE_COLOR_CLASS[profileImageUrl] ?? "bg-neutral-300"
+                  : "bg-neutral-900"
+              }`}
+            >
+              {profileInitial || "?"}
+            </div>
+          )}
         </div>
       </motion.div>
 
@@ -104,7 +124,6 @@ export function HomePage() {
         config={transitionConfig}
       />
 
-      {/* 하단 신상 팩 영역 */}
       <section className="mt-8">
         <h2 className="text-[18px] font-bold text-neutral-900">
           지금 등록된 따끈따끈한 신상 팩

--- a/src/views/my-pack/ui/components/MyPack.tsx
+++ b/src/views/my-pack/ui/components/MyPack.tsx
@@ -13,6 +13,8 @@ import { useMyPack } from "@/views/my-pack/model/useMyPack";
 import Tag1Btn from "@/shared/ui/Tag1Btn";
 import { MOMENT_OPTIONS } from "@/views/onboarding/model/constants";
 import { useGetItems } from "@/entities/item/model/useGetItems";
+import { useUserStore, isProfileDefaultColor } from "@/entities/user/model";
+import { PROFILE_COLOR_CLASS } from "@/views/my-page/ui/MyPage";
 
 interface MyPackProps {
     onGoToItemAdd: () => void;
@@ -20,13 +22,33 @@ interface MyPackProps {
 
 export const MyPack = ({ onGoToItemAdd }: MyPackProps) => {
     const { state, actions } = useMyPack();
+    const { user } = useUserStore();
 
     const { data } = useGetItems();
+    const nickname = user?.name ?? "사용자";
+    const profileImageUrl = user?.profileImageUrl;
+    const profileInitial = nickname.charAt(0).toUpperCase();
     return (
         <div className="px-6 pb-24">
             <header className={`flex items-center justify-between mt-16 ${state.isFilterOpen ? 'mb-5' : 'mb-10'}`}>
                 <div className="flex-1 flex justify-start">
-                    <div className="w-12 h-12 bg-common-100 rounded-full" />
+                    {profileImageUrl && !isProfileDefaultColor(profileImageUrl) ? (
+                        <div
+                            className="w-12 h-12 rounded-full bg-neutral-300 bg-cover bg-center"
+                            style={{ backgroundImage: `url(${profileImageUrl})` }}
+                            aria-label={`${nickname} 프로필 이미지`}
+                            role="img"
+                        />
+                    ) : (
+                        <div
+                            className={`w-12 h-12 rounded-full flex items-center justify-center text-white font-bold ${profileImageUrl && isProfileDefaultColor(profileImageUrl)
+                                ? PROFILE_COLOR_CLASS[profileImageUrl] ?? "bg-neutral-300"
+                                : "bg-common-100"
+                                }`}
+                        >
+                            {profileInitial || "?"}
+                        </div>
+                    )}
                 </div>
 
                 <div role="tablist" className="flex gap-7 w-37 items-center justify-center">

--- a/src/views/wishlist/ui/WishlistPage.tsx
+++ b/src/views/wishlist/ui/WishlistPage.tsx
@@ -6,11 +6,16 @@ import { PackCard, type PackCardData } from "@/shared/ui/item/PackCard";
 import { MOCK_PACK_CARDS } from "@/features/search/model/mock";
 import TabItem from "@/shared/ui/TabItem";
 import { useWishlist } from "@/entities/wishlist/model/useWishlist";
+import { useUserStore, isProfileDefaultColor } from "@/entities/user/model";
+import { PROFILE_COLOR_CLASS } from "@/views/my-page/ui/MyPage";
 
 type ActiveTab = "item" | "pack";
 
 export default function WishListPage() {
-  const nickname = "홍길동"; // TODO: 유저 닉네임 연결
+  const { user } = useUserStore();
+  const nickname = user?.name ?? "사용자";
+  const profileImageUrl = user?.profileImageUrl;
+  const profileInitial = nickname.charAt(0).toUpperCase();
 
   const { data: wishlist, isLoading } = useWishlist();
 
@@ -51,7 +56,7 @@ export default function WishListPage() {
   if (isLoading) return <div className="p-10 text-center">로딩 중...</div>;
 
   return (
-    <main className="min-h-dvh bg-background-alternative2 px-5 pt-12 pb-28">
+    <main className="min-h-dvh bg-background-normal px-5 pt-12 pb-28">
       <div className="flex items-start justify-between">
         <div>
           <h1 className="type-heading1 text-label-default">
@@ -61,7 +66,24 @@ export default function WishListPage() {
           </h1>
         </div>
         <div className="shrink-0">
-          <div className="h-14 w-14 rounded-full bg-neutral-900" />
+          {profileImageUrl && !isProfileDefaultColor(profileImageUrl) ? (
+            <div
+              className="h-14 w-14 rounded-full bg-neutral-300 bg-cover bg-center"
+              style={{ backgroundImage: `url(${profileImageUrl})` }}
+              aria-label={`${nickname} 프로필 이미지`}
+              role="img"
+            />
+          ) : (
+            <div
+              className={`h-14 w-14 rounded-full flex items-center justify-center text-white font-bold ${
+                profileImageUrl && isProfileDefaultColor(profileImageUrl)
+                  ? PROFILE_COLOR_CLASS[profileImageUrl] ?? "bg-neutral-300"
+                  : "bg-neutral-900"
+              }`}
+            >
+              {profileInitial || "?"}
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/widgets/home-search-header/ui/HomeSearchHeader.tsx
+++ b/src/widgets/home-search-header/ui/HomeSearchHeader.tsx
@@ -15,14 +15,18 @@ export function HomeSearchHeader({ onSearchBarClick, onFilterClick }: Props) {
   const router = useRouter();
   const { setFromHome } = useSearchTransitionContext();
 
-  const goSearchPage = useCallback(() => {
-    if (onSearchBarClick) {
-      onSearchBarClick();
-      return;
-    }
-    setFromHome(true);
-    router.push("/search", { scroll: false });
-  }, [router, onSearchBarClick, setFromHome]);
+  const goSearchPage = useCallback(
+    (q: string) => {
+      if (onSearchBarClick) {
+        onSearchBarClick();
+        return;
+      }
+
+      setFromHome(true);
+      router.push(`/search?q=${encodeURIComponent(q)}`, { scroll: false });
+    },
+    [router, onSearchBarClick, setFromHome]
+  );
 
   const goFilterSearchPage = useCallback(() => {
     if (onFilterClick) {
@@ -40,7 +44,7 @@ export function HomeSearchHeader({ onSearchBarClick, onFilterClick }: Props) {
             isSearchMode={false}
             query=""
             onChange={() => {}}
-            onEnterSearchMode={goSearchPage}
+            onSearch={goSearchPage}
           />
         </div>
 

--- a/src/widgets/search/model/useSearchState.ts
+++ b/src/widgets/search/model/useSearchState.ts
@@ -4,6 +4,8 @@ import * as React from "react";
 import { useSearchParams } from "next/navigation";
 import { parseCategoriesParam, slugToLabel } from "@/features/search/model/categories";
 import { MOCK_PACK_CARDS } from "@/features/search/model/mock";
+import { useSearchPacks } from "@/features/search/model/useSearchPacks";
+import { useDebounce } from "@/shared/lib/useDebounce";
 
 export function useSearchState(query: string) {
   const searchParams = useSearchParams();
@@ -21,25 +23,33 @@ export function useSearchState(query: string) {
     [categorySlugs]
   );
 
-  const normalizedQuery = query.trim().toLowerCase();
+  const debouncedQuery = useDebounce(query, 350);
+  const normalizedQuery = debouncedQuery.trim().toLowerCase();
+
+  const { data: searchedPacks = [] } = useSearchPacks(debouncedQuery);
+  const mappedSearchResults = React.useMemo(
+    () => searchedPacks.map((pack) => ({
+      id: pack.id,
+      tag: pack.tag,
+      itemCount: pack.itemCount,
+      title: pack.title,
+      author: pack.author,
+      liked: pack.liked ?? false,
+      description: pack.description,
+      date: pack.date,
+    })),
+    [searchedPacks]
+  );
 
   const filteredPacks = React.useMemo(() => {
-    let list = MOCK_PACK_CARDS;
+    let list = normalizedQuery ? mappedSearchResults : MOCK_PACK_CARDS;
 
     if (selectedLabels.length) {
       list = list.filter((p) => selectedLabels.includes(p.tag));
     }
 
-    if (normalizedQuery) {
-      list = list.filter((p) =>
-        `${p.title} ${p.author} ${p.tag}`
-          .toLowerCase()
-          .includes(normalizedQuery)
-      );
-    }
-
     return list;
-  }, [selectedLabels, normalizedQuery]);
+  }, [selectedLabels, normalizedQuery, mappedSearchResults]);
 
   const hasIntent = selectedLabels.length > 0 || normalizedQuery.length > 0;
   const isEmpty = hasIntent && filteredPacks.length === 0;

--- a/src/widgets/search/ui/SearchResultSection.tsx
+++ b/src/widgets/search/ui/SearchResultSection.tsx
@@ -15,7 +15,7 @@ export function SearchResultSection({
   recommended,
 }: Props) {
   const hasResults = packs.length > 0;
-  
+
   if (hasResults) {
     return (
       <section className="px-4 pt-6">
@@ -30,7 +30,6 @@ export function SearchResultSection({
     );
   }
 
-  // ✅ 검색 결과가 진짜로 0개일 때만 empty UI + 추천 노출
   return (
     <section className="px-4 pt-6">
       <div className="pt-24 text-center">

--- a/src/widgets/search/ui/SearchResultSection.tsx
+++ b/src/widgets/search/ui/SearchResultSection.tsx
@@ -4,30 +4,47 @@ import { PackCard, type PackCardData } from "@/shared/ui/item/PackCard";
 
 interface Props {
   packs: PackCardData[];
-  isEmpty: boolean;
+  isEmpty: boolean; 
   nickname: string;
   recommended: PackCardData[];
 }
 
 export function SearchResultSection({
   packs,
-  isEmpty,
   nickname,
   recommended,
 }: Props) {
-  if (isEmpty) {
+  const hasResults = packs.length > 0;
+  
+  if (hasResults) {
     return (
       <section className="px-4 pt-6">
-        <div className="pt-24 text-center">
-          <p className="type-headline1">
-            검색 결과가 없습니다. <br />
-            직접 첫 번째 팩의 주인공이 되어보세요!
-          </p>
-        </div>
+        <ul className="flex flex-col gap-4">
+          {packs.map((card) => (
+            <li key={card.id}>
+              <PackCard {...card} />
+            </li>
+          ))}
+        </ul>
+      </section>
+    );
+  }
 
+  // ✅ 검색 결과가 진짜로 0개일 때만 empty UI + 추천 노출
+  return (
+    <section className="px-4 pt-6">
+      <div className="pt-24 text-center">
+        <p className="type-headline1">
+          검색 결과가 없습니다. <br />
+          직접 첫 번째 팩의 주인공이 되어보세요!
+        </p>
+      </div>
+
+      {recommended.length > 0 && (
         <div className="mt-24">
           <h2 className="type-heading1">
-            <span className="text-primary-normal">{nickname}</span>님을 위한 맞춤 팩 어때요?
+            <span className="text-primary-normal">{nickname}</span>님을 위한 맞춤 팩
+            어때요?
           </h2>
 
           <ul className="mt-6 flex flex-col gap-4">
@@ -38,19 +55,7 @@ export function SearchResultSection({
             ))}
           </ul>
         </div>
-      </section>
-    );
-  }
-
-  return (
-    <section className="px-4 pt-6">
-      <ul className="flex flex-col gap-4">
-        {packs.map((card) => (
-          <li key={card.id}>
-            <PackCard {...card} />
-          </li>
-        ))}
-      </ul>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## 📌 Summary

> #️⃣ 연관된 이슈

<!-- close #123 -->

close #57

---

## 📋 작업 상세 내용

<!-- "•" 으로 상세 표기 -->
- home 상단, 마이팩, 위시리스트에 프로필이미지/유저정보 적용

연결
- home 내 지금뜨는 태그 연결
- 입력을 통한 검색 api 연결

미연결  
- home 추천 아이템은 500서버에러로 미연결
- Search 내 카테고리 선택 후 검색결과 -> 백엔드 논의중

---

### 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->

### 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

https://www.notion.so/API-3115021e838e80e48cc9d81bb6c71da1?source=copy_link

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->

## 📸 스크린샷 (선택)



https://github.com/user-attachments/assets/9ce455df-7728-4056-9f01-050bb8b69eba




<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyword-based pack search functionality across the application.
  * Introduced dynamic trending tags section on home page with organized categories.
  * Enhanced search results with improved no-results messaging and fallback content suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->